### PR TITLE
Added falsy URL verification

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ homepage: "https://github.com/episodicza/ssgtm_filter_querystring"
 documentation: "https://github.com/episodicza/ssgtm_filter_querystring#readme"
 versions:
   - sha: 6ec15930b616c4a1fa95b24aae282baf2a40e83b
-    changeNotes: Added falsy URL to parse verification.
+    changeNotes: Added falsy URL verification.
   - sha: 483abac46eb79933d7b9c14210678ef24615992b
     changeNotes: Initial release.
     

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://github.com/episodicza/ssgtm_filter_querystring"
 documentation: "https://github.com/episodicza/ssgtm_filter_querystring#readme"
 versions:
+  - sha: 6ec15930b616c4a1fa95b24aae282baf2a40e83b
+    changeNotes: Added falsy URL to parse verification.
   - sha: 483abac46eb79933d7b9c14210678ef24615992b
     changeNotes: Initial release.
     

--- a/template.tpl
+++ b/template.tpl
@@ -116,7 +116,9 @@ const decodeUriComponent = require('decodeUriComponent');
 const log = require('logToConsole');
 
 const url = data.urlSource === 'event_page_location' ? getEventData('page_location') : data.urlSource;
-const parsedUrl = parseUrl(url);
+const parsedUrl = parseUrl(URL);
+
+if (!parsedUrl) return;
 
 if (!parsedUrl.search) return url;
 


### PR DESCRIPTION
Hi @skaaptjop 

I noticed that when using this template with a parameter that can hold a string but is not always populated, the code throws an exception at
```
if (!parsedUrl.search) return URL;
```

I just added a verification before that to make sure the code doesn't run when there's no content in the `parsedUrl` variable.